### PR TITLE
Fix typo in AICommitCommand

### DIFF
--- a/src/Command/AICommitCommand.php
+++ b/src/Command/AICommitCommand.php
@@ -41,7 +41,7 @@ class AICommitCommand extends Command
         $this->io = new SymfonyStyle($input, $output);
 
         if ($input->getOption('reset')) {
-            $this->io->note('Reseting env variable:'.OpenAIService::OPENAI_API_KEY);
+            $this->io->note('Resetting env variable:'.OpenAIService::OPENAI_API_KEY);
             EnvironmentHelper::removeEnvVar(
                 OpenAIService::OPENAI_API_KEY,
             );


### PR DESCRIPTION
## Summary
- correct a typo in AICommitCommand

## Testing
- `make check` *(fails: `php: not found`)*
- `make test` *(fails: `php: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846bb39bbcc832bbbd17176afa896b0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typo in the user-facing message when resetting the OpenAI API key environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->