### PR TITLE
Fix stash drop command

### DIFF
--- a/src/Helper/GitHelper.php
+++ b/src/Helper/GitHelper.php
@@ -112,7 +112,7 @@ class GitHelper
             throw new \RuntimeException(Message::GIT_UNAVAILABLE->value);
         }
 
-        $process = new Process(['git', 'stash', 'drop', "stash@{$index}"]);
+        $process = new Process(['git', 'stash', 'drop', "stash@{{$index}}"]);
         $process->run();
 
         if (!$process->isSuccessful()) {


### PR DESCRIPTION
## Summary
- correct the git stash drop syntax
- test stash removal to ensure correct command
- import Process class instead of using full qualified name

## Testing
- `vendor/bin/phpunit --testdox --display-deprecations`


------
https://chatgpt.com/codex/tasks/task_e_6846b7f8c1e4832b826490654455f9cf