### PR TITLE
Prepare for Packagist release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Luiz Mesquita
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ my list
 
 ## 🚀 Installation
 
-You can install My Commands in two ways:
+You can install My Commands in three ways:
 
 ### Option 1: Using the Installation Script (Recommended)
 
@@ -99,6 +99,16 @@ If you prefer step-by-step manual installation:
    ```bash
    source ~/.zshrc  # or source ~/.bashrc
    ```
+
+### Option 3: Install via Composer
+
+Once this package is available on [Packagist](https://packagist.org) you can
+install it globally with Composer:
+
+```bash
+composer global require luizalbertobm/mycommands
+```
+
 
 ## 🔧 Usage
 
@@ -202,6 +212,13 @@ class YourNewCommand extends Command
 ```
 
 2. Register your command in `bin/console`.
+
+## 📦 Publishing to Packagist
+
+1. Push your repository to a public hosting service like GitHub.
+2. Tag a release, for example `git tag v1.0.0 && git push --tags`.
+3. Create an account on [Packagist](https://packagist.org) and submit the repository URL.
+4. Once approved, users can install the package via Composer as shown above.
 
 ## 🤝 Contributing
 

--- a/composer.json
+++ b/composer.json
@@ -1,39 +1,41 @@
 {
-    "name": "luizalbertobm/mycommands",
-    "description": "A bunch of useful terminal commands",
-    "type": "library",
-    "require": {
-        "php": "^8.3",
-        "ext-xml": "*",
-        "ext-mbstring": "*",
-        "symfony/console": "^7.2",
-        "symfony/process": "^7.2",
-        "symfony/http-client": "^7.2",
-        "react/http": "^1.11",
-        "react/event-loop": "^1.5"
-    },
-    "autoload": {
-        "psr-4": {
-            "MyCommands\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "MyCommands\\Tests\\": "tests/"
-        }
-    },
-    "bin": [
-        "bin/console"
-    ],
-    "authors": [
-        {
-            "name": "Luiz Mesquita",
-            "email": "luizalbertobm@gmail.com"
-        }
-    ],
-    "require-dev": {
-        "phpstan/phpstan": "^2.1",
-        "phpunit/phpunit": "^10.5",
-        "mikey179/vfsstream": "^1.6"
+  "name": "luizalbertobm/mycommands",
+  "description": "A bunch of useful terminal commands",
+  "type": "library",
+  "require": {
+    "php": "^8.3",
+    "ext-xml": "*",
+    "ext-mbstring": "*",
+    "symfony/console": "^7.2",
+    "symfony/process": "^7.2",
+    "symfony/http-client": "^7.2",
+    "react/http": "^1.11",
+    "react/event-loop": "^1.5"
+  },
+  "autoload": {
+    "psr-4": {
+      "MyCommands\\": "src/"
     }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "MyCommands\\Tests\\": "tests/"
+    }
+  },
+  "bin": [
+    "bin/console"
+  ],
+  "authors": [
+    {
+      "name": "Luiz Mesquita",
+      "email": "luizalbertobm@gmail.com"
+    }
+  ],
+  "require-dev": {
+    "phpstan/phpstan": "^2.1",
+    "phpunit/phpunit": "^10.5",
+    "mikey179/vfsstream": "^1.6"
+  },
+  "license": "MIT"
 }
+


### PR DESCRIPTION
## Summary
- add MIT license file
- note new installation method using Composer
- document how to publish the library on Packagist
- include license in composer.json

## Testing
- `composer install`
- `./vendor/bin/phpunit --configuration phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_6846c039b2d0832b908c4efb37f01df0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the README to include a new global installation method via Composer and added instructions for publishing to Packagist.

- **Chores**
  - Added an MIT License file.
  - Included license information in the project metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->