### PR TITLE
Increase test coverage

### DIFF
--- a/tests/Command/AICommitCommandTest.php
+++ b/tests/Command/AICommitCommandTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace MyCommands\Tests\Command;
+
+use MyCommands\Command\AICommitCommand;
+use PHPUnit\Framework\TestCase;
+
+class AICommitCommandTest extends TestCase
+{
+    private function callCleanMessage(string $message): string
+    {
+        $reflection = new \ReflectionClass(AICommitCommand::class);
+        $method = $reflection->getMethod('cleanMessage');
+        $method->setAccessible(true);
+        $instance = $reflection->newInstance();
+
+        return $method->invoke($instance, $message);
+    }
+
+    public function testCleanMessageRemovesCodeBlock(): void
+    {
+        $input = "```php\n<?php echo 'test'; ?>\n```";
+        $expected = "<?php echo 'test'; ?";
+        $this->assertSame($expected, $this->callCleanMessage($input));
+    }
+
+    public function testCleanMessageTrimsSpecialChars(): void
+    {
+        $input = "***Fix***";
+        $this->assertSame('Fix', $this->callCleanMessage($input));
+    }
+
+    public function testCleanMessageHandlesEmptyString(): void
+    {
+        $this->assertSame('', $this->callCleanMessage(''));
+    }
+}

--- a/tests/DTO/OpenAIPayloadTest.php
+++ b/tests/DTO/OpenAIPayloadTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace MyCommands\Tests\DTO;
+
+use MyCommands\DTO\OpenAIPayload;
+use MyCommands\Message;
+use PHPUnit\Framework\TestCase;
+
+class OpenAIPayloadTest extends TestCase
+{
+    public function testToArrayForCommit(): void
+    {
+        $payload = new OpenAIPayload('msg', isCommit: true);
+        $data = $payload->toArray();
+        $this->assertSame(Message::SYSTEM_ROLE_COMMIT->value, $data['messages'][0]['content']);
+        $this->assertSame('msg', $data['messages'][1]['content']);
+    }
+
+    public function testToArrayForAsk(): void
+    {
+        $payload = new OpenAIPayload('hello', isCommit: false);
+        $data = $payload->toArray();
+        $this->assertSame(Message::SYSTEM_ROLE_ASK->value, $data['messages'][0]['content']);
+        $this->assertSame('hello', $data['messages'][1]['content']);
+    }
+}

--- a/tests/Helper/DockerHelperTest.php
+++ b/tests/Helper/DockerHelperTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace MyCommands\Tests\Helper;
+
+use MyCommands\Helper\DockerHelper;
+use PHPUnit\Framework\TestCase;
+
+class DockerHelperTest extends TestCase
+{
+    private string $tmpDir;
+    private string $oldPath;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/docker_stub_' . uniqid();
+        mkdir($this->tmpDir);
+        $script = <<<'SH'
+#!/bin/sh
+if [ "$1" = "ps" ] && [ "$2" = "--format" ]; then
+    if [ "$DOCKER_TEST_EMPTY" = "1" ]; then
+        exit 0
+    fi
+    echo "123|test_container|image:test|0.0.0.0:80->80/tcp"
+    echo "456|other_container|image:other|"
+    exit 0
+fi
+if [ "$1" = "ps" ] && [ "$2" = "-q" ]; then
+    if [ "$DOCKER_TEST_EMPTY" = "1" ]; then
+        exit 0
+    fi
+    echo "123"
+    echo "456"
+    exit 0
+fi
+if [ "$1" = "stop" ]; then
+    shift
+    for id in "$@"; do
+        echo "$id"
+    done
+    exit 0
+fi
+exit 0
+SH;
+        $path = $this->tmpDir . '/docker';
+        file_put_contents($path, $script);
+        chmod($path, 0755);
+        $this->oldPath = getenv('PATH');
+        putenv('PATH=' . $this->tmpDir . ':' . $this->oldPath);
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('PATH=' . $this->oldPath);
+        @unlink($this->tmpDir . '/docker');
+        @rmdir($this->tmpDir);
+    }
+
+    public function testGetContainerRowsAndIds(): void
+    {
+        $helper = new DockerHelper();
+        $rows = $helper->getContainerRows();
+        $ids = $helper->getContainerIds();
+        $stopped = $helper->stopContainers($ids);
+
+        $expectedRows = [
+            [1, '123', 'test_container', 'image:test', '0.0.0.0:80->80/tcp'],
+            [2, '456', 'other_container', 'image:other', '-'],
+        ];
+        $this->assertSame($expectedRows, $rows);
+        $this->assertSame(['123', '456'], $ids);
+        $this->assertSame(['123', '456'], $stopped);
+    }
+
+    public function testGetContainerRowsEmpty(): void
+    {
+        putenv('DOCKER_TEST_EMPTY=1');
+        $_ENV['DOCKER_TEST_EMPTY'] = '1';
+        $helper = new DockerHelper();
+        $this->assertSame([], $helper->getContainerRows());
+        $this->assertSame([], $helper->getContainerIds());
+        $this->assertSame([], $helper->stopContainers([]));
+        putenv('DOCKER_TEST_EMPTY');
+        unset($_ENV['DOCKER_TEST_EMPTY']);
+    }
+}


### PR DESCRIPTION
## Summary
- add DockerHelper tests covering container listing, ids and stop
- test AICommitCommand message cleaning via reflection
- test DTO OpenAIPayload conversions

## Testing
- `vendor/bin/phpunit --display-warnings`

------
https://chatgpt.com/codex/tasks/task_e_6847175c094c832b9c72f6f3662e0d91