### PR TITLE
Add post-install hook for composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ If you prefer step-by-step manual installation:
 ### Option 3: Install via Composer
 
 Once this package is available on [Packagist](https://packagist.org) you can
-install it globally with Composer:
+install it globally with Composer. The installer script will run automatically
+after installation:
 
 ```bash
 composer global require luizalbertobm/mycommands

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,14 @@
     "phpunit/phpunit": "^10.5",
     "mikey179/vfsstream": "^1.6"
   },
+  "scripts": {
+    "post-install-cmd": [
+      "bash -c \"SKIP_COMPOSER_INSTALL=1 ./install.sh\""
+    ],
+    "post-update-cmd": [
+      "bash -c \"SKIP_COMPOSER_INSTALL=1 ./install.sh\""
+    ]
+  },
   "license": "MIT"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -14,8 +14,10 @@ then
     exit 1
 fi
 
-echo "Installing dependencies..."
-composer install
+if [ -z "$SKIP_COMPOSER_INSTALL" ]; then
+    echo "Installing dependencies..."
+    composer install
+fi
 
 echo "Creating a symbolic link..."
 sudo ln -sf $(pwd)/bin/console /usr/local/bin/my

--- a/src/Command/ZipAllCommand.php
+++ b/src/Command/ZipAllCommand.php
@@ -42,10 +42,10 @@ class ZipAllCommand extends Command
 
         return Command::SUCCESS;
     }
-    
+
     /**
      * Get a ZipHelper instance
-     * This method can be overridden in tests
+     * This method can be overridden in tests.
      */
     protected function getZipHelper(): ZipHelper
     {

--- a/tests/Command/AICommitCommandTest.php
+++ b/tests/Command/AICommitCommandTest.php
@@ -26,7 +26,7 @@ class AICommitCommandTest extends TestCase
 
     public function testCleanMessageTrimsSpecialChars(): void
     {
-        $input = "***Fix***";
+        $input = '***Fix***';
         $this->assertSame('Fix', $this->callCleanMessage($input));
     }
 

--- a/tests/Command/CurrencyConvertCommandTest.php
+++ b/tests/Command/CurrencyConvertCommandTest.php
@@ -4,8 +4,8 @@ namespace MyCommands\Tests\Command;
 
 use MyCommands\Command\CurrencyConvertCommand;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 

--- a/tests/Command/ZipAllCommandTest.php
+++ b/tests/Command/ZipAllCommandTest.php
@@ -14,116 +14,117 @@ class ZipAllCommandTest extends TestCase
     {
         // Create a custom ZipHelper that doesn't actually create files
         $zipHelperStub = $this->createMock(ZipHelper::class);
-        
+
         // Create a test command that uses our stub
         $command = new class($zipHelperStub) extends ZipAllCommand {
             private $zipHelperStub;
-            
-            public function __construct($zipHelperStub) 
+
+            public function __construct($zipHelperStub)
             {
                 $this->zipHelperStub = $zipHelperStub;
                 parent::__construct();
             }
-            
-            protected function getZipHelper(): ZipHelper 
+
+            protected function getZipHelper(): ZipHelper
             {
                 return $this->zipHelperStub;
             }
         };
-        
+
         $commandTester = new CommandTester($command);
         $exitCode = $commandTester->execute([]);
-        
+
         $this->assertEquals(0, $exitCode);
         $this->assertStringContainsString('Zip archive created at:', $commandTester->getDisplay());
     }
-    
+
     public function testDirectGetZipHelper(): void
     {
         $command = new ZipAllCommand();
-        
+
         // Get the ZipHelper instance using reflection to verify the method works correctly
         $reflectionClass = new \ReflectionClass(ZipAllCommand::class);
         $method = $reflectionClass->getMethod('getZipHelper');
         $method->setAccessible(true);
-        
+
         $zipHelper = $method->invoke($command);
-        
+
         // Assert that the method returned a ZipHelper instance
         $this->assertInstanceOf(ZipHelper::class, $zipHelper);
-        
+
         // Also directly execute the method to ensure proper coverage
         $zipHelperDirect = $this->callProtectedMethod($command, 'getZipHelper');
         $this->assertInstanceOf(ZipHelper::class, $zipHelperDirect);
     }
-    
+
     /**
-     * Helper method to call protected methods
+     * Helper method to call protected methods.
      */
     private function callProtectedMethod($object, $methodName, array $parameters = [])
     {
         $reflection = new \ReflectionClass(get_class($object));
         $method = $reflection->getMethod($methodName);
         $method->setAccessible(true);
-        
+
         return $method->invokeArgs($object, $parameters);
     }
-    
+
     public function testExecuteFailureWhenZipHelperThrowsException(): void
     {
         // Create a custom ZipHelper that throws an exception
         $zipHelperStub = $this->createMock(ZipHelper::class);
         $zipHelperStub->method('zipDirectory')
                      ->willThrowException(new \RuntimeException('Test exception'));
-        
+
         // Create a test command that uses our stub
         $command = new class($zipHelperStub) extends ZipAllCommand {
             private $zipHelperStub;
-            
-            public function __construct($zipHelperStub) 
+
+            public function __construct($zipHelperStub)
             {
                 $this->zipHelperStub = $zipHelperStub;
                 parent::__construct();
             }
-            
-            protected function getZipHelper(): ZipHelper 
+
+            protected function getZipHelper(): ZipHelper
             {
                 return $this->zipHelperStub;
             }
         };
-        
+
         $commandTester = new CommandTester($command);
         $exitCode = $commandTester->execute([]);
-        
+
         $this->assertEquals(Command::FAILURE, $exitCode);
         $this->assertStringContainsString('Test exception', $commandTester->getDisplay());
     }
-    
+
     public function testExecuteFailureWhenGetcwdFails(): void
     {
         // Create a test command that simulates getcwd() failing
         $command = new class extends ZipAllCommand {
             protected function execute(
-                \Symfony\Component\Console\Input\InputInterface $input, 
-                \Symfony\Component\Console\Output\OutputInterface $output
+                \Symfony\Component\Console\Input\InputInterface $input,
+                \Symfony\Component\Console\Output\OutputInterface $output,
             ): int {
                 $io = new \Symfony\Component\Console\Style\SymfonyStyle($input, $output);
                 $io->error('Failed to determine the current working directory.');
+
                 return Command::FAILURE;
             }
         };
-        
+
         $commandTester = new CommandTester($command);
         $exitCode = $commandTester->execute([]);
-        
+
         $this->assertEquals(Command::FAILURE, $exitCode);
-        $this->assertStringContainsString('Failed to determine the current working directory', 
-                                         $commandTester->getDisplay());
+        $this->assertStringContainsString('Failed to determine the current working directory',
+            $commandTester->getDisplay());
     }
 
     /**
      * Test the full execute method with a real getZipHelper implementation
-     * that is mocked to not actually create files
+     * that is mocked to not actually create files.
      */
     public function testConfigureMethodAndExecuteWithRealImplementation(): void
     {
@@ -131,75 +132,77 @@ class ZipAllCommandTest extends TestCase
         $command = $this->getMockBuilder(ZipAllCommand::class)
             ->onlyMethods(['getZipHelper'])
             ->getMock();
-        
+
         // Create a mock of ZipHelper
         $zipHelperMock = $this->createMock(ZipHelper::class);
-        
+
         // Configure the mock to expect zipDirectory call - void return type
         $zipHelperMock->expects($this->once())
             ->method('zipDirectory');
-        
+
         // Set up the command to return our mock
         $command->expects($this->once())
             ->method('getZipHelper')
             ->willReturn($zipHelperMock);
-        
+
         // Test the command - need to cast to Command since it's a MockObject
         $commandTester = new CommandTester($command);
         $exitCode = $commandTester->execute([]);
-        
+
         // Validate results
         $this->assertEquals(Command::SUCCESS, $exitCode);
         $this->assertStringContainsString('Zip archive created at:', $commandTester->getDisplay());
     }
-    
+
     /**
-     * Test that the command has the correct name and description
+     * Test that the command has the correct name and description.
      */
     public function testCommandConfiguration(): void
     {
         $command = new ZipAllCommand();
-        
+
         $this->assertEquals('zip:all', $command->getName());
         $this->assertEquals(
-            'Compresses all files in the current directory where the command is executed', 
+            'Compresses all files in the current directory where the command is executed',
             $command->getDescription()
         );
         $this->assertEquals('', $command->getHelp(), 'Help text should be empty by default');
     }
-    
+
     /**
-     * Test execute method with mocked getcwd function
+     * Test execute method with mocked getcwd function.
      */
     public function testExecuteWithMockedGetcwd(): void
     {
         // Create a command that uses a fixed directory path
         $command = new class extends ZipAllCommand {
             protected function execute(
-                \Symfony\Component\Console\Input\InputInterface $input, 
-                \Symfony\Component\Console\Output\OutputInterface $output
+                \Symfony\Component\Console\Input\InputInterface $input,
+                \Symfony\Component\Console\Output\OutputInterface $output,
             ): int {
                 // Mock the functionality of the execute method with a predetermined current directory
                 $io = new \Symfony\Component\Console\Style\SymfonyStyle($input, $output);
                 $cwd = '/fixed/test/path';
-                $zipPath = $cwd . DIRECTORY_SEPARATOR . 'test.zip';
-                
+                $zipPath = $cwd.DIRECTORY_SEPARATOR.'test.zip';
+
                 $helper = $this->getZipHelper();
                 try {
                     // We won't actually call zipDirectory here because we've already tested that path
                     // This avoids the need for complex file system mocking
-                    $io->success('Zip archive created at: ' . $zipPath);
+                    $io->success('Zip archive created at: '.$zipPath);
+
                     return Command::SUCCESS;
                 } catch (\RuntimeException $e) {
                     $io->error($e->getMessage());
+
                     return Command::FAILURE;
                 }
             }
         };
-        
+
         $commandTester = new CommandTester($command);
         $exitCode = $commandTester->execute([]);
-        
+
         $this->assertEquals(Command::SUCCESS, $exitCode);
         $this->assertStringContainsString('Zip archive created at: /fixed/test/path/test.zip', $commandTester->getDisplay());
     }

--- a/tests/Helper/DockerHelperTest.php
+++ b/tests/Helper/DockerHelperTest.php
@@ -12,7 +12,7 @@ class DockerHelperTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->tmpDir = sys_get_temp_dir() . '/docker_stub_' . uniqid();
+        $this->tmpDir = sys_get_temp_dir().'/docker_stub_'.uniqid();
         mkdir($this->tmpDir);
         $script = <<<'SH'
 #!/bin/sh
@@ -41,17 +41,17 @@ if [ "$1" = "stop" ]; then
 fi
 exit 0
 SH;
-        $path = $this->tmpDir . '/docker';
+        $path = $this->tmpDir.'/docker';
         file_put_contents($path, $script);
         chmod($path, 0755);
         $this->oldPath = getenv('PATH');
-        putenv('PATH=' . $this->tmpDir . ':' . $this->oldPath);
+        putenv('PATH='.$this->tmpDir.':'.$this->oldPath);
     }
 
     protected function tearDown(): void
     {
-        putenv('PATH=' . $this->oldPath);
-        @unlink($this->tmpDir . '/docker');
+        putenv('PATH='.$this->oldPath);
+        @unlink($this->tmpDir.'/docker');
         @rmdir($this->tmpDir);
     }
 

--- a/tests/Helper/EnvironmentHelperTest.php
+++ b/tests/Helper/EnvironmentHelperTest.php
@@ -120,46 +120,46 @@ class EnvironmentHelperTest extends TestCase
     {
         // First save the variable to shell
         EnvironmentHelper::saveEnvVar($this->testEnvVar, $this->testValue);
-        
+
         // Verify it exists
         $shell = EnvironmentHelper::getShell();
         $beforeContent = file_get_contents($shell);
         $this->assertStringContainsString("export {$this->testEnvVar}", $beforeContent);
-        
+
         // Test removing the variable
         $result = EnvironmentHelper::removeEnvVar($this->testEnvVar);
-        
+
         // Verify it was removed
         $this->assertTrue($result);
         $afterContent = file_get_contents($shell);
         $this->assertStringNotContainsString("export {$this->testEnvVar}", $afterContent);
-        
+
         // Verify the environment variable was removed from the environment
         $this->assertFalse(getenv($this->testEnvVar));
     }
-    
+
     public function testIsEnvVarInShellFile()
     {
         $shell = EnvironmentHelper::getShell();
         if (!$shell) {
             $this->markTestSkipped('No shell file found to test');
         }
-        
+
         // Create a backup of the shell file
         $backupContent = file_get_contents($shell);
-        
+
         // Test with variable that doesn't exist
         $this->assertFalse(EnvironmentHelper::isEnvVarInShellFile('NON_EXISTENT_VAR', $shell));
-        
+
         // Add test variable to shell file
         file_put_contents($shell, "export {$this->testEnvVar}='{$this->testValue}'\n", FILE_APPEND);
-        
+
         // Test with variable that exists
         $this->assertTrue(EnvironmentHelper::isEnvVarInShellFile($this->testEnvVar, $shell));
-        
+
         // Test with non-existent file
         $this->assertFalse(EnvironmentHelper::isEnvVarInShellFile($this->testEnvVar, '/path/to/nonexistent/file'));
-        
+
         // Restore the original content
         file_put_contents($shell, $backupContent);
     }
@@ -171,65 +171,65 @@ class EnvironmentHelperTest extends TestCase
     {
         // Save the current HOME environment variable
         $originalHome = getenv('HOME');
-        
+
         // Create a temporary directory where we know no shell files will exist
-        $tempDir = sys_get_temp_dir() . '/non_existent_dir_' . uniqid();
+        $tempDir = sys_get_temp_dir().'/non_existent_dir_'.uniqid();
         mkdir($tempDir, 0777, true);
-        
+
         // Set HOME to the temp directory
-        putenv('HOME=' . $tempDir);
-        
+        putenv('HOME='.$tempDir);
+
         // Test that getShell returns null when no shell files exist
         $this->assertNull(EnvironmentHelper::getShell());
-        
+
         // Clean up
-        putenv('HOME=' . ($originalHome !== false ? $originalHome : ''));
+        putenv('HOME='.(false !== $originalHome ? $originalHome : ''));
         if (is_dir($tempDir)) {
             rmdir($tempDir);
         }
     }
-    
+
     public function testSaveEnvVarWithNoShellFile()
     {
         // Create a temporary directory to use as HOME
-        $tempDir = sys_get_temp_dir() . '/no_shell_' . uniqid();
+        $tempDir = sys_get_temp_dir().'/no_shell_'.uniqid();
         mkdir($tempDir, 0777, true);
-        
+
         // Save original HOME and set temporary HOME
         $originalHome = getenv('HOME');
-        putenv('HOME=' . $tempDir);
-        
+        putenv('HOME='.$tempDir);
+
         // Verify getShell returns null with this setup
         $this->assertNull(EnvironmentHelper::getShell());
-        
+
         // Test saveEnvVar when no shell file exists
         $result = EnvironmentHelper::saveEnvVar($this->testEnvVar, $this->testValue);
-        
+
         // Expect false since there's no shell file
         $this->assertFalse($result);
-        
+
         // Verify the env var was still set in the environment
         $this->assertEquals($this->testValue, getenv($this->testEnvVar));
-        
+
         // Clean up
-        putenv('HOME=' . ($originalHome !== false ? $originalHome : ''));
+        putenv('HOME='.(false !== $originalHome ? $originalHome : ''));
         if (is_dir($tempDir)) {
             rmdir($tempDir);
         }
     }
-    
+
     public function testGetEnvVarFromShellWithInvalidShell()
     {
         // Create a non-existent file path
-        $nonExistentFile = '/path/to/nonexistent/file_' . uniqid();
-        
+        $nonExistentFile = '/path/to/nonexistent/file_'.uniqid();
+
         // Mock a scenario where the shell file doesn't exist
         $mockHelper = $this->createMock(EnvironmentHelper::class);
         $reflectionClass = new \ReflectionClass(EnvironmentHelper::class);
-        
+
         // Use reflection to access the getEnvVarFromShell method
         $method = $reflectionClass->getMethod('getEnvVarFromShell');
-        
+
         // Try with a non-existent var
         $result = EnvironmentHelper::getEnvVarFromShell('NON_EXISTENT_VAR');
         $this->assertNull($result);
@@ -240,20 +240,20 @@ class EnvironmentHelperTest extends TestCase
         // Make sure environment is clean
         putenv($this->testEnvVar);
         unset($_SERVER[$this->testEnvVar]);
-        
+
         // Add variable to shell file
         $shell = EnvironmentHelper::getShell();
         if (!$shell) {
             $this->markTestSkipped('No shell file found to test');
         }
-        
+
         $backupContent = file_get_contents($shell);
         file_put_contents($shell, "export {$this->testEnvVar}='special_shell_value'\n", FILE_APPEND);
-        
+
         // Get the variable, which should come from shell
         $result = EnvironmentHelper::getEnvVar($this->testEnvVar);
         $this->assertEquals('special_shell_value', $result);
-        
+
         // Restore the shell file
         file_put_contents($shell, $backupContent);
     }
@@ -264,20 +264,20 @@ class EnvironmentHelperTest extends TestCase
     public function testIsEnvVarInShellFileWithNonReadableFile()
     {
         // Create a temp file that we'll make non-readable
-        $tempFile = sys_get_temp_dir() . '/test_unreadable_' . uniqid();
+        $tempFile = sys_get_temp_dir().'/test_unreadable_'.uniqid();
         file_put_contents($tempFile, 'test content');
-        
+
         // Since we can't safely mock static methods in PHPUnit easily,
         // let's create a test environment where we know the behavior
         // without actually needing to change file permissions
-        
+
         // This is a simpler approach - we know the implementation checks for is_readable
         // so we can create a class with a known state
         $this->assertFalse(EnvironmentHelper::isEnvVarInShellFile(
-            $this->testEnvVar, 
+            $this->testEnvVar,
             '/path/that/definitely/does/not/exist'
         ));
-        
+
         // Cleanup
         unlink($tempFile);
     }
@@ -288,19 +288,19 @@ class EnvironmentHelperTest extends TestCase
     public function testGetEnvVarFromShellWhenShellContentCannotBeRead()
     {
         // Create a temporary file that we can manipulate for testing
-        $tempFile = sys_get_temp_dir() . '/test_shell_' . uniqid();
+        $tempFile = sys_get_temp_dir().'/test_shell_'.uniqid();
         touch($tempFile);
-        
+
         // Set the HOME environment variable to point to a non-existent path
         $originalHome = getenv('HOME');
         putenv('HOME=/path/that/does/not/exist');
-        
+
         // This should return null when the shell file doesn't exist
         $result = EnvironmentHelper::getEnvVarFromShell('NON_EXISTENT_VAR');
         $this->assertNull($result);
-        
+
         // Clean up
-        putenv('HOME=' . ($originalHome !== false ? $originalHome : ''));
+        putenv('HOME='.(false !== $originalHome ? $originalHome : ''));
         if (file_exists($tempFile)) {
             unlink($tempFile);
         }

--- a/tests/Helper/ZipHelperTest.php
+++ b/tests/Helper/ZipHelperTest.php
@@ -3,9 +3,9 @@
 namespace MyCommands\Tests\Helper;
 
 use MyCommands\Helper\ZipHelper;
-use PHPUnit\Framework\TestCase;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\TestCase;
 
 class ZipHelperTest extends TestCase
 {
@@ -22,43 +22,43 @@ class ZipHelperTest extends TestCase
         $testContent = 'test content';
         vfsStream::newFile('file1.txt')->withContent($testContent)->at($this->root);
         vfsStream::newFile('subdir/file2.txt')->withContent($testContent)->at($this->root);
-        
+
         $sourceDir = vfsStream::url('testDir');
-        $zipPath = sys_get_temp_dir() . '/test.zip';
-        
+        $zipPath = sys_get_temp_dir().'/test.zip';
+
         // Delete the zip file if it already exists
         if (file_exists($zipPath)) {
             unlink($zipPath);
         }
-        
+
         $zipHelper = new ZipHelper();
         $zipHelper->zipDirectory($sourceDir, $zipPath);
-        
+
         // Assert zip file exists
         $this->assertFileExists($zipPath);
-        
+
         // Verify zip contents
         $zip = new \ZipArchive();
         $this->assertTrue($zip->open($zipPath));
-        
+
         $this->assertEquals(2, $zip->numFiles);
-        $this->assertTrue($zip->locateName('file1.txt') !== false);
-        $this->assertTrue($zip->locateName('subdir/file2.txt') !== false);
-        
+        $this->assertTrue(false !== $zip->locateName('file1.txt'));
+        $this->assertTrue(false !== $zip->locateName('subdir/file2.txt'));
+
         $zip->close();
-        
+
         // Clean up
         unlink($zipPath);
     }
-    
+
     public function testZipDirectoryThrowsExceptionOnInvalidPath(): void
     {
         $this->expectException(\RuntimeException::class);
-        
+
         $zipHelper = new ZipHelper();
         $nonExistentPath = '/path/that/doesnt/exist';
-        $zipPath = sys_get_temp_dir() . '/test_invalid.zip';
-        
+        $zipPath = sys_get_temp_dir().'/test_invalid.zip';
+
         $zipHelper->zipDirectory($nonExistentPath, $zipPath);
     }
 }


### PR DESCRIPTION
## Summary
- run install script during composer install/update
- skip composer install inside install.sh when triggered via composer
- document automatic install script in README
- fix coding style

## Testing
- `composer install`
- `make check`
- `make xdebug.enable`
- `make test` *(fails: No code coverage driver available)*

------
https://chatgpt.com/codex/tasks/task_e_6847405d4568832b96fe2f97053a092c